### PR TITLE
Fix #12 "--check"-mode run fails due to undefined existing_sudoer_spec_list

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Controls the configuration of the sudoers file and /etc/sudoers.d/ files
   issue_tracker_url: https://github.com/wtcross/ansible-sudoers/issues
   license: MIT
-  min_ansible_version: 1.2
+  min_ansible_version: 2.0
   #github_branch: master
   platforms:
     - name: EL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,13 +28,15 @@
     state: directory
 
 - name: Find all existing separate sudoer specs
-  shell: find /etc/sudoers.d -type f -printf "%f\n"
+  find:
+    paths: "/etc/sudoers.d"
+    file_type: file
+    recurse: no
   register: existing_sudoer_spec_list
-  changed_when: False
 
 - name: Get a list of all existing separate sudoer specs
   set_fact:
-    existing_sudoer_specs: "{{ existing_sudoer_spec_list.stdout_lines }}"
+    existing_sudoer_specs: "{{ existing_sudoer_spec_list.files | map(attribute='path') | map('regex_replace','(.*\\/)(.*)','\\2') | list}}"
   changed_when: False
 
 - name: Get a list of all authorized separate sudoer spec names


### PR DESCRIPTION
Fixes issue #12 by converting existing_sudoer_spec_list shell task to idempotent find task