### PR TITLE
Fixed example playbook syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,39 +55,39 @@ Defaults:MONITOR_USER    !logfile
       user:
             - name: ADMINS
               comment: Group of admin users
-          users:
-            - %admin
+              users:
+                - '%admin'
           runas:
             - name: ROOT
               comment: Root stuff
-          users:
-            - '#0'
+              users:
+                - '#0'
       host:
             - name: SERVERS
               comment: XYZ servers
-          hosts:
-            - 192.168.0.1
-            - 192.168.0.2
+              hosts:
+                - 192.168.0.1
+                - 192.168.0.2
       command:
             - name: ADMIN_CMNDS
               comment: Stuff admins need
               commands:
-            - /usr/sbin/passwd
-            - /usr/sbin/useradd
-            - /usr/sbin/userdel
-            - /usr/sbin/usermod
-            - /usr/sbin/visudo
+                - /usr/sbin/passwd
+                - /usr/sbin/useradd
+                - /usr/sbin/userdel
+                - /usr/sbin/usermod
+                - /usr/sbin/visudo
     sudoer_specs:
       - name: administrators
             comment: Stuff for admins
             users: ADMIN
-        hosts: SERVERS
-        operators: ROOT
-        tags:
-          - NOPASSWD
-        commands: ADMIN_CMNDS
-        defaults:
-          - '!requiretty'
+            hosts: SERVERS
+            operators: ROOT
+            tags:
+              - NOPASSWD
+            commands: ADMIN_CMNDS
+            defaults:
+              - '!requiretty'
 
   roles:
     - wtcross.sudoers

--- a/README.md
+++ b/README.md
@@ -51,46 +51,47 @@ Defaults:MONITOR_USER    !logfile
 ```yaml
 - hosts: all
   vars:
-    sudoer_aliases:
-      user:
-            - name: ADMINS
-              comment: Group of admin users
-              users:
-                - '%admin'
-          runas:
-            - name: ROOT
-              comment: Root stuff
-              users:
-                - '#0'
-      host:
-            - name: SERVERS
-              comment: XYZ servers
-              hosts:
-                - 192.168.0.1
-                - 192.168.0.2
-      command:
-            - name: ADMIN_CMNDS
-              comment: Stuff admins need
-              commands:
-                - /usr/sbin/passwd
-                - /usr/sbin/useradd
-                - /usr/sbin/userdel
-                - /usr/sbin/usermod
-                - /usr/sbin/visudo
-    sudoer_specs:
-      - name: administrators
-            comment: Stuff for admins
-            users: ADMIN
-            hosts: SERVERS
-            operators: ROOT
-            tags:
-              - NOPASSWD
-            commands: ADMIN_CMNDS
-            defaults:
-              - '!requiretty'
+      sudoer_aliases:
+        user:
+          - name: ADMINS
+            comment: Group of admin users
+            users:
+              - "%admin"
+        runas:
+          - name: ROOT
+            comment: Root stuff
+            users:
+              - '#0'
+        host:
+          - name: SERVERS
+            comment: XYZ servers
+            hosts:
+              - 192.168.0.1
+              - 192.168.0.2
+        command:
+          - name: ADMIN_CMNDS
+            comment: Stuff admins need
+            commands:
+              - /usr/sbin/passwd
+              - /usr/sbin/useradd
+              - /usr/sbin/userdel
+              - /usr/sbin/usermod
+              - /usr/sbin/visudo
+
+      sudoer_specs:
+        - name: administrators
+          comment: Stuff for admins
+          users: ADMIN
+          hosts: SERVERS
+          operators: ROOT
+          tags:
+            - NOPASSWD
+          commands: ADMIN_CMNDS
+          defaults:
+            - '!requiretty'
 
   roles:
-    - wtcross.sudoers
+    - sudoers
 ```
 
 ## Defaults:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Defaults:MONITOR_USER    !logfile
             - '!requiretty'
 
   roles:
-    - sudoers
+    - wtcross.sudoers
 ```
 
 ## Defaults:


### PR DESCRIPTION
Fixed improper indentation that made a copy/paste of the example playbook unusable.