### PR TITLE
correct example playbook definition by changing TAGS to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ Defaults:MONITOR_USER    !logfile
           users: ADMIN
           hosts: SERVERS
           operators: ROOT
-          tags:
-            - NOPASSWD
+          tags: NOPASSWD
           commands: ADMIN_CMNDS
           defaults:
             - '!requiretty'


### PR DESCRIPTION
Just a small correction of an example playbook where TAGS were set as a list rather than type causing playbook to fail