### PR TITLE
allow adding per host/group specific sudoers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 sudoer_aliases: {}
 sudoer_specs: []
+sudoer_specs_extra: []
 sudoer_defaults:
 #  - requiretty
   - "!visiblepw"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
 
 - name: Get a list of all authorized separate sudoer spec names
   set_fact:
-    authorized_sudoer_specs: "{{ sudoer_specs | map(attribute='name') | list }}"
+    authorized_sudoer_specs: "{{ sudoer_specs | map(attribute='name') | list }} + {{ sudoer_specs_extra | map(attribute='name') | list }}" 
   changed_when: False
 
 - name: Ensure all authorized separate sudoer specs are properly configured
@@ -52,7 +52,7 @@
     group: root
     mode: 0440
     validate: visudo -cf %s
-  with_items: '{{ sudoer_specs }}'
+  with_items: '{{ sudoer_specs }} + {{ sudoer_specs_extra }}'
   when: "sudoer_separate_specs | bool"
 
 - name: Ensure the sudoers file is valid and up to date (separate specs)


### PR DESCRIPTION
This change allows adding host/group of hosts specific sudoers so now we can have i.e sudoer_specs in group_vars for all hosts and sudoer_specs_extra for specific hosts or groups