### PR TITLE
Change dict.iteritems to dict.items.

### DIFF
--- a/templates/sudoers_nospec.j2
+++ b/templates/sudoers_nospec.j2
@@ -2,7 +2,7 @@
 
 {% for default in sudoer_defaults %}
 {% if default is mapping %}
-{% for name, values in default.iteritems() %}
+{% for name, values in default.items() %}
 {% for items in values | to_list | slice(6) %}
 {% if items %}
 Defaults    {{ name }} {% if not loop.first %}+{% endif %}= "{{ items | to_list | join(' ') }}"

--- a/templates/sudoers_plus_spec.j2
+++ b/templates/sudoers_plus_spec.j2
@@ -2,7 +2,7 @@
 
 {% for default in sudoer_defaults %}
 {% if default is mapping %}
-{% for name, values in default.iteritems() %}
+{% for name, values in default.items() %}
 {% for items in values | to_list | slice(6) %}
 {% if items %}
 Defaults    {{ name }} {% if not loop.first %}+{% endif %}= "{{ items | to_list | join(' ') }}"


### PR DESCRIPTION
Since ansible 2.7, python 2.6 is not supported anymore on the control host, iteritems doesn't exist anymore in python 3 and dict.items is available in python 2.7.

https://github.com/ansible/ansible/pull/42971
https://docs.python.org/2/library/stdtypes.html#dict.items