### PR TITLE
Play nice with macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers`
 | sudoers_backup_path | Path relative to where you are executing your playbook to backup the remote copies of defined `sudoers_files` to. | "sudoers_backups" | string |
 | sudoers_visudo_path | Fully-qualified path to the `visudo` binary required for validation of sudoers configuration changes. Added for Operating System compatibility. | "/usr/sbin/visudo" | string |
 | sudoers_files | Definition of all your sudoers configurations | see [defaults/main.yml](defaults/main.yml)| list of dictionaries |
+| sudoers_root_group | Group to be used when creating and verifying files | "wheel" on macOS and "root" everywhere else | string |
 
 ## sudoers_files Dictionary Fields
 | Variable Name | Description | Variable Type |

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# ahuffman.sudoers
+# Ansible Sudoers
 
 Controls the configuration of the default `/etc/sudoers` file and included files/directories.
 
 ---
-***Please note, release 2.0.0+ is a major re-write of the role.  Please read the documentation to ensure you understand the changes prior to installation and use if coming from prior versions.***
+
+**This is direct fork of [ahuffman.ansible-sudoers](https://galaxy.ansible.com/ahuffman/sudoers)
+role. It simply add changes to allow you to use this role on _macOS_ machines.**
 
 ---
 
 ## Table of Contents
+
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:0 orderedList:1 -->
 
-- [ahuffman.sudoers](#ahuffmansudoers)
+- [Sudoers](#ahuffmansudoers)
   - [Table of Contents](#table-of-contents)
   - [Tips](#tips)
   - [Role Variables](#role-variables)
@@ -39,72 +42,72 @@ Controls the configuration of the default `/etc/sudoers` file and included files
 
 ## Tips
 
-|*Tip:* Here's a few excellent resources on sudoers configuration:|
-|---|
-|[Start here](https://help.ubuntu.com/community/Sudoers) - Provides a great run-down on basic sudoers file configurations and terminology|
-|[Sudoers Manual](https://www.sudo.ws/man/1.8.15/sudoers.man.html) - If you want to know all the details, this is for you.|
+| _Tip:_ Here's a few excellent resources on sudoers configuration:                                                                        |
+| ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [Start here](https://help.ubuntu.com/community/Sudoers) - Provides a great run-down on basic sudoers file configurations and terminology |
+| [Sudoers Manual](https://www.sudo.ws/man/1.8.15/sudoers.man.html) - If you want to know all the details, this is for you.                |
 
 ## Role Variables
 
-The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers` configuration.  Please check the defaults in [`defaults/main.yml`](defaults/main.yml) prior to running for OS compatibility.
+The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers` configuration. Please check the defaults in [`defaults/main.yml`](defaults/main.yml) prior to running for OS compatibility.
 
-| Variable Name | Description | Default Value | Variable Type |
-| --- | --- | :---: | :---: |
-| sudoers_rewrite_default_sudoers_file | Use role default or user defined `sudoers_files` definition, replacing your distribution supplied `/etc/sudoers` file.  Useful when attempting to deploy new configuration files to the `include_directories` and you do not wish to modify the `/etc/sudoers` file. | True | boolean |
-| sudoers_remove_unauthorized_included_files | ***Very Dangerous!*** Each existing sudoer file found in the `include_directories` dictionary which have not been defined in `sudoers_files` will be removed. This allows for enforcing a desired state. | False | boolean |
-| sudoers_backup | Whether or not to create a backup of the current state of the existing `/etc/sudoers` file as well as any files defined in `sudoers_files`.  The files get backed up to the Ansible control node (Server you are executing Ansible from) and avoids accidentally leaving files behind in your `include_directories` that may be evaluated by the sudoers configuration(s).| True | boolean |
-| sudoers_backup_path | Path relative to where you are executing your playbook to backup the remote copies of defined `sudoers_files` to. | "sudoers_backups" | string |
-| sudoers_visudo_path | Fully-qualified path to the `visudo` binary required for validation of sudoers configuration changes. Added for Operating System compatibility. | "/usr/sbin/visudo" | string |
-| sudoers_files | Definition of all your sudoers configurations | see [defaults/main.yml](defaults/main.yml)| list of dictionaries |
-| sudoers_root_group | Group to be used when creating and verifying files | "wheel" on macOS and "root" everywhere else | string |
+| Variable Name                              | Description                                                                                                                                                                                                                                                                                                                                                               |                Default Value                |    Variable Type     |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----------------------------------------: | :------------------: |
+| sudoers_rewrite_default_sudoers_file       | Use role default or user defined `sudoers_files` definition, replacing your distribution supplied `/etc/sudoers` file. Useful when attempting to deploy new configuration files to the `include_directories` and you do not wish to modify the `/etc/sudoers` file.                                                                                                       |                    True                     |       boolean        |
+| sudoers_remove_unauthorized_included_files | **_Very Dangerous!_** Each existing sudoer file found in the `include_directories` dictionary which have not been defined in `sudoers_files` will be removed. This allows for enforcing a desired state.                                                                                                                                                                  |                    False                    |       boolean        |
+| sudoers_backup                             | Whether or not to create a backup of the current state of the existing `/etc/sudoers` file as well as any files defined in `sudoers_files`. The files get backed up to the Ansible control node (Server you are executing Ansible from) and avoids accidentally leaving files behind in your `include_directories` that may be evaluated by the sudoers configuration(s). |                    True                     |       boolean        |
+| sudoers_backup_path                        | Path relative to where you are executing your playbook to backup the remote copies of defined `sudoers_files` to.                                                                                                                                                                                                                                                         |              "sudoers_backups"              |        string        |
+| sudoers_visudo_path                        | Fully-qualified path to the `visudo` binary required for validation of sudoers configuration changes. Added for Operating System compatibility.                                                                                                                                                                                                                           |             "/usr/sbin/visudo"              |        string        |
+| sudoers_files                              | Definition of all your sudoers configurations                                                                                                                                                                                                                                                                                                                             | see [defaults/main.yml](defaults/main.yml)  | list of dictionaries |
+| sudoers_root_group                         | Group to be used when creating and verifying files                                                                                                                                                                                                                                                                                                                        | "wheel" on macOS and "root" everywhere else |        string        |
 
 ## sudoers_files Dictionary Fields
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| path | Where to deploy the configuration file to on the filesystem. | string |
-| aliases | Optional definition of `cmnd_alias`, `host_alias`, `runas_alias`, or `user_alias` items. | dictionary |
-| defaults | This allows you to define the defaults of your sudoers configuration. Default overrides can be perfomed via the [`user_specifications`](#default-override-user_specifications) key.| list |
-| include_files | Optional specific files that you would like your configuration to include.  This is a list of fully-qualified paths to include via the `#include` option of a sudoers configuration. | list |
-| include_directories | Optional specific directories that you would like your configurations to include.  This is a list of fully-qualified paths to directories to include via the `#includedir` option of a sudoers configuration. | list |
-| user_specifications | List of user specifications and default overrides to apply to a sudoers file configuration. | list |
+| Variable Name       | Description                                                                                                                                                                                                  | Variable Type |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-----------: |
+| path                | Where to deploy the configuration file to on the filesystem.                                                                                                                                                 |    string     |
+| aliases             | Optional definition of `cmnd_alias`, `host_alias`, `runas_alias`, or `user_alias` items.                                                                                                                     |  dictionary   |
+| defaults            | This allows you to define the defaults of your sudoers configuration. Default overrides can be perfomed via the [`user_specifications`](#default-override-user_specifications) key.                          |     list      |
+| include_files       | Optional specific files that you would like your configuration to include. This is a list of fully-qualified paths to include via the `#include` option of a sudoers configuration.                          |     list      |
+| include_directories | Optional specific directories that you would like your configurations to include. This is a list of fully-qualified paths to directories to include via the `#includedir` option of a sudoers configuration. |     list      |
+| user_specifications | List of user specifications and default overrides to apply to a sudoers file configuration.                                                                                                                  |     list      |
 
 ### sudoers_files.aliases Dictionary Fields
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| cmnd_alias | List of command alias definitions. | list of dictionaries |
-| host_alias | List of host alias definitions | list of dictionaries |
-| runas_alias | List of runas alias definitions | list of dictionaries |
-| user_alias | List of user alias definitions | list of dictionaries |
+| Variable Name | Description                        |    Variable Type     |
+| ------------- | ---------------------------------- | :------------------: |
+| cmnd_alias    | List of command alias definitions. | list of dictionaries |
+| host_alias    | List of host alias definitions     | list of dictionaries |
+| runas_alias   | List of runas alias definitions    | list of dictionaries |
+| user_alias    | List of user alias definitions     | list of dictionaries |
 
 #### cmnd_alias Dictionary Fields
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| name | Name of the command alias. | string |
-| commands | List of commands to apply to the alias | list |
+| Variable Name | Description                            | Variable Type |
+| ------------- | -------------------------------------- | :-----------: |
+| name          | Name of the command alias.             |    string     |
+| commands      | List of commands to apply to the alias |     list      |
 
 #### host_alias Dictionary Fields
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| name | Name of the host alias. | string |
-| hosts | List of hosts to apply to the alias | list |
+| Variable Name | Description                         | Variable Type |
+| ------------- | ----------------------------------- | :-----------: |
+| name          | Name of the host alias.             |    string     |
+| hosts         | List of hosts to apply to the alias |     list      |
 
 #### runas_alias Dictionary Fields
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| name | Name of the runas alias | string |
-| users | List of users to apply to the alias | list |
+| Variable Name | Description                         | Variable Type |
+| ------------- | ----------------------------------- | :-----------: |
+| name          | Name of the runas alias             |    string     |
+| users         | List of users to apply to the alias |     list      |
 
 #### user_alias Dictionary Fields
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| name | Name of the user_alias | string |
-| users | List of users to apply to the alias | list |
+| Variable Name | Description                         | Variable Type |
+| ------------- | ----------------------------------- | :-----------: |
+| name          | Name of the user_alias              |    string     |
+| users         | List of users to apply to the alias |     list      |
 
 ### user_specifications Dictionary Fields
 
@@ -112,32 +115,32 @@ This dictionary can be used to assign either user specifications or default over
 
 #### Standard user_specifications
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| users | List of users to apply the specification to. You can use a `user_alias` name as well as user names. | list |
-| hosts | List of hosts to apply the specification to.  You can use a defined `host_alias` name as well as host names. | list |
-| operators | List of operators to apply the specification to. You can use a defined `runas_alias` name as well as user names. | list |
-| selinux_role | Optional selinux role to apply to the specification | list |
-| selinux_type | Optional selinux type to apply to the specification | list |
-| solaris_privs | Optional Solaris privset to apply to the specification | list |
-| solaris_limitprivs | Optional Solaris privset to apply to the specification | list |
-| tags | Optional list of tags to apply to the specification. | list |
-| commands | List of commands to apply the specification to.  You can use a defined `cmnd_alias` name as well as commands. | list |
+| Variable Name      | Description                                                                                                      | Variable Type |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- | :-----------: |
+| users              | List of users to apply the specification to. You can use a `user_alias` name as well as user names.              |     list      |
+| hosts              | List of hosts to apply the specification to. You can use a defined `host_alias` name as well as host names.      |     list      |
+| operators          | List of operators to apply the specification to. You can use a defined `runas_alias` name as well as user names. |     list      |
+| selinux_role       | Optional selinux role to apply to the specification                                                              |     list      |
+| selinux_type       | Optional selinux type to apply to the specification                                                              |     list      |
+| solaris_privs      | Optional Solaris privset to apply to the specification                                                           |     list      |
+| solaris_limitprivs | Optional Solaris privset to apply to the specification                                                           |     list      |
+| tags               | Optional list of tags to apply to the specification.                                                             |     list      |
+| commands           | List of commands to apply the specification to. You can use a defined `cmnd_alias` name as well as commands.     |     list      |
 
 #### Default Override user_specifications
 
-| Variable Name | Description | Variable Type |
-| --- | --- | :---: |
-| defaults | List of defaults to override from the main configuration | list |
-| type | Type of default to override, this affects the operator in the configuration ( host -> `@`, user -> `:`, command -> `!`, and runas -> `>`).  The type field can be one of the following values: `command`, `host`, `runas`, or `user`. | string |
-| commands | Use when `type: "command"`.  List of `cmnd_alias` names as well as commands to override specific default values.| list |
-| hosts | Use when `type: "host"`.  List of `host_alias` names as well as individual host names to override specific default values. | list |
-| operators | Use when `type: "runas"`. List of `runas_alias` names as well as individual user names to override specific default values. | list |
-| users | Use when `type: "user"`.  List of `user_alias` names as well as individual user names to override specific default values. | list |
+| Variable Name | Description                                                                                                                                                                                                                          | Variable Type |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-----------: |
+| defaults      | List of defaults to override from the main configuration                                                                                                                                                                             |     list      |
+| type          | Type of default to override, this affects the operator in the configuration ( host -> `@`, user -> `:`, command -> `!`, and runas -> `>`). The type field can be one of the following values: `command`, `host`, `runas`, or `user`. |    string     |
+| commands      | Use when `type: "command"`. List of `cmnd_alias` names as well as commands to override specific default values.                                                                                                                      |     list      |
+| hosts         | Use when `type: "host"`. List of `host_alias` names as well as individual host names to override specific default values.                                                                                                            |     list      |
+| operators     | Use when `type: "runas"`. List of `runas_alias` names as well as individual user names to override specific default values.                                                                                                          |     list      |
+| users         | Use when `type: "user"`. List of `user_alias` names as well as individual user names to override specific default values.                                                                                                            |     list      |
 
 ## Automatically Generating the Sudoers Files Data from an Existing Configuration
 
-Does this all sound way too complicated to configure from the documentation?  Please check out and try [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) to find a role that can auto-generate the proper data structure for you.  With the [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) role, you can take a running configuration in one play, and lay it down on another with the [ahuffman.sudoers](https://galaxy.ansible.com/ahuffman/sudoers) role (version 2.0.0+).  You could also opt to take the collected data and push it into a source of truth such as a CMDB or repository via automation.  The collected data that is generated by [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) and can be consumed by [ahuffman.sudoers](https://galaxy.ansible.com/ahuffman/sudoers) would be `{{ ansible_facts['sudoers'].sudoers_files }}`.
+Does this all sound way too complicated to configure from the documentation? Please check out and try [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) to find a role that can auto-generate the proper data structure for you. With the [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) role, you can take a running configuration in one play, and lay it down on another with the [ahuffman.sudoers](https://galaxy.ansible.com/ahuffman/sudoers) role (version 2.0.0+). You could also opt to take the collected data and push it into a source of truth such as a CMDB or repository via automation. The collected data that is generated by [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) and can be consumed by [ahuffman.sudoers](https://galaxy.ansible.com/ahuffman/sudoers) would be `{{ ansible_facts['sudoers'].sudoers_files }}`.
 
 This should help alleviate some of the complication of manually defining the sudoers configurations as code, and get you up and running much quicker.
 
@@ -214,7 +217,7 @@ root ALL=(ALL) ALL
             defaults:
               - "!visiblepw"
               - "always_set_home"
-              - "match_group_by_gid"        # NOTE: for sudo>=1.8.18
+              - "match_group_by_gid" # NOTE: for sudo>=1.8.18
               - "always_query_group_plugin" # NOTE: maintains sudo pre-1.8.15 group behavior
               - "env_reset"
               - secure_path:
@@ -386,7 +389,7 @@ Defaults>root !set_logname
         sudoers_remove_unauthorized_included_files: True
 ```
 
-The above example provides a method of using Infrastructure-as-Code in Reverse to take a known configuration converted to structured data to drive future automation.  Alternatively to directly provisioning the collected configuration on a new host, you could push the data into a CMDB or repository for future use as a source of truth.
+The above example provides a method of using Infrastructure-as-Code in Reverse to take a known configuration converted to structured data to drive future automation. Alternatively to directly provisioning the collected configuration on a new host, you could push the data into a CMDB or repository for future use as a source of truth.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,39 +10,42 @@ Controls the configuration of the default `/etc/sudoers` file and included files
 ## Table of Contents
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:0 orderedList:1 -->
 
-1. [Table of Contents](#table-of-contents)
-2. [Tips](#tips)
-3. [Role Variables](#role-variables)
-4. [sudoers_files Dictionary Fields](#sudoers_files-dictionary-fields)
-	1. [sudoers_files.aliases Dictionary Fields](#sudoers_filesaliases-dictionary-fields)
-		1. [cmnd_alias Dictionary Fields](#cmnd_alias-dictionary-fields)
-		2. [host_alias Dictionary Fields](#host_alias-dictionary-fields)
-		3. [runas_alias Dictionary Fields](#runas_alias-dictionary-fields)
-		4. [user_alias Dictionary Fields](#user_alias-dictionary-fields)
-	2. [user_specifications Dictionary Fields](#user_specifications-dictionary-fields)
-		1. [Standard user_specifications](#standard-user_specifications)
-		2. [Default Override user_specifications](#default-override-user_specifications)
-5. [Automatically Generating the Sudoers Files Data from an Existing Configuration](#automatically-generating-the-sudoers-files-data-from-an-existing-configuration)
-6. [Example Playbooks](#example-playbooks)
-	1. [RHEL7.6 Default Sudoers Configuration](#rhel76-default-sudoers-configuration)
-		1. [Results: /etc/sudoers](#results-etcsudoers)
-	2. [Sudoers Configuration (multiple files)](#sudoers-configuration-multiple-files)
-		1. [Results: /etc/sudoers](#results-etcsudoers)
-		2. [Results: /etc/sudoers.d/pingers](#results-etcsudoersdpingers)
-		3. [Results: /etc/sudoers.d/root](#results-etcsudoersdroot)
-	3. [Migrating a Running Sudoers Configuration to Another Host](#migrating-a-running-sudoers-configuration-to-another-host)
-11. [License](#license)
-12. [Author Information](#author-information)
+- [ahuffman.sudoers](#ahuffmansudoers)
+  - [Table of Contents](#table-of-contents)
+  - [Tips](#tips)
+  - [Role Variables](#role-variables)
+  - [sudoers_files Dictionary Fields](#sudoersfiles-dictionary-fields)
+    - [sudoers_files.aliases Dictionary Fields](#sudoersfilesaliases-dictionary-fields)
+      - [cmnd_alias Dictionary Fields](#cmndalias-dictionary-fields)
+      - [host_alias Dictionary Fields](#hostalias-dictionary-fields)
+      - [runas_alias Dictionary Fields](#runasalias-dictionary-fields)
+      - [user_alias Dictionary Fields](#useralias-dictionary-fields)
+    - [user_specifications Dictionary Fields](#userspecifications-dictionary-fields)
+      - [Standard user_specifications](#standard-userspecifications)
+      - [Default Override user_specifications](#default-override-userspecifications)
+  - [Automatically Generating the Sudoers Files Data from an Existing Configuration](#automatically-generating-the-sudoers-files-data-from-an-existing-configuration)
+  - [Example Playbooks](#example-playbooks)
+    - [RHEL7.6 Default Sudoers Configuration](#rhel76-default-sudoers-configuration)
+      - [Results: /etc/sudoers](#results-etcsudoers)
+    - [Sudoers Configuration (multiple files)](#sudoers-configuration-multiple-files)
+      - [Results: /etc/sudoers (multiple files)](#results-etcsudoers-multiple-files)
+      - [Results: /etc/sudoers.d/pingers](#results-etcsudoersdpingers)
+      - [Results: /etc/sudoers.d/root](#results-etcsudoersdroot)
+    - [Migrating a Running Sudoers Configuration to Another Host](#migrating-a-running-sudoers-configuration-to-another-host)
+  - [License](#license)
+  - [Author Information](#author-information)
 
 <!-- /TOC -->
 
 ## Tips
+
 |*Tip:* Here's a few excellent resources on sudoers configuration:|
 |---|
 |[Start here](https://help.ubuntu.com/community/Sudoers) - Provides a great run-down on basic sudoers file configurations and terminology|
 |[Sudoers Manual](https://www.sudo.ws/man/1.8.15/sudoers.man.html) - If you want to know all the details, this is for you.|
 
 ## Role Variables
+
 The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers` configuration.  Please check the defaults in [`defaults/main.yml`](defaults/main.yml) prior to running for OS compatibility.
 
 | Variable Name | Description | Default Value | Variable Type |
@@ -55,6 +58,7 @@ The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers`
 | sudoers_files | Definition of all your sudoers configurations | see [defaults/main.yml](defaults/main.yml)| list of dictionaries |
 
 ## sudoers_files Dictionary Fields
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | path | Where to deploy the configuration file to on the filesystem. | string |
@@ -65,6 +69,7 @@ The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers`
 | user_specifications | List of user specifications and default overrides to apply to a sudoers file configuration. | list |
 
 ### sudoers_files.aliases Dictionary Fields
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | cmnd_alias | List of command alias definitions. | list of dictionaries |
@@ -73,33 +78,39 @@ The defaults defined for this role are based on a default RHEL7.6 `/etc/sudoers`
 | user_alias | List of user alias definitions | list of dictionaries |
 
 #### cmnd_alias Dictionary Fields
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | name | Name of the command alias. | string |
 | commands | List of commands to apply to the alias | list |
 
 #### host_alias Dictionary Fields
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | name | Name of the host alias. | string |
 | hosts | List of hosts to apply to the alias | list |
 
 #### runas_alias Dictionary Fields
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | name | Name of the runas alias | string |
 | users | List of users to apply to the alias | list |
 
 #### user_alias Dictionary Fields
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | name | Name of the user_alias | string |
 | users | List of users to apply to the alias | list |
 
 ### user_specifications Dictionary Fields
+
 This dictionary can be used to assign either user specifications or default overrides.
 
 #### Standard user_specifications
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | users | List of users to apply the specification to. You can use a `user_alias` name as well as user names. | list |
@@ -113,6 +124,7 @@ This dictionary can be used to assign either user specifications or default over
 | commands | List of commands to apply the specification to.  You can use a defined `cmnd_alias` name as well as commands. | list |
 
 #### Default Override user_specifications
+
 | Variable Name | Description | Variable Type |
 | --- | --- | :---: |
 | defaults | List of defaults to override from the main configuration | list |
@@ -123,22 +135,26 @@ This dictionary can be used to assign either user specifications or default over
 | users | Use when `type: "user"`.  List of `user_alias` names as well as individual user names to override specific default values. | list |
 
 ## Automatically Generating the Sudoers Files Data from an Existing Configuration
+
 Does this all sound way too complicated to configure from the documentation?  Please check out and try [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) to find a role that can auto-generate the proper data structure for you.  With the [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) role, you can take a running configuration in one play, and lay it down on another with the [ahuffman.sudoers](https://galaxy.ansible.com/ahuffman/sudoers) role (version 2.0.0+).  You could also opt to take the collected data and push it into a source of truth such as a CMDB or repository via automation.  The collected data that is generated by [ahuffman.scan_sudoers](https://galaxy.ansible.com/ahuffman/scan_sudoers) and can be consumed by [ahuffman.sudoers](https://galaxy.ansible.com/ahuffman/sudoers) would be `{{ ansible_facts['sudoers'].sudoers_files }}`.
 
 This should help alleviate some of the complication of manually defining the sudoers configurations as code, and get you up and running much quicker.
 
 See the [Playbook Example](#migrating-a-running-sudoers-configuration-to-another-host) below.
 
-
 ## Example Playbooks
+
 ### RHEL7.6 Default Sudoers Configuration
+
 ```yaml
 - name: "Apply a RHEL7.6 Default /etc/sudoers configuration"
   hosts: "all"
   roles:
     - role: "ahuffman.sudoers"
 ```
+
 ...or with modern syntax:
+
 ```yaml
 - name: "Apply a RHEL7.6 Default /etc/sudoers configuration"
   hosts: "all"
@@ -149,8 +165,10 @@ See the [Playbook Example](#migrating-a-running-sudoers-configuration-to-another
 ```
 
 #### Results: /etc/sudoers
+
 The above two examples using the role defaults will produce a `/etc/sudoers` configuration file that looks like this:
-```
+
+```ini
 # Ansible managed
 
 # Default specifications
@@ -177,6 +195,7 @@ root ALL=(ALL) ALL
 ```
 
 ### Sudoers Configuration (multiple files)
+
 ```yaml
 - name: "Apply a multi-file sudoers configuration"
   hosts: "all"
@@ -194,8 +213,8 @@ root ALL=(ALL) ALL
             defaults:
               - "!visiblepw"
               - "always_set_home"
-              - "match_group_by_gid"
-              - "always_query_group_plugin" # maintains sudo pre-1.8.15 group behavior
+              - "match_group_by_gid"        # NOTE: for sudo>=1.8.18
+              - "always_query_group_plugin" # NOTE: maintains sudo pre-1.8.15 group behavior
               - "env_reset"
               - secure_path:
                   - "/sbin"
@@ -277,9 +296,12 @@ root ALL=(ALL) ALL
                 operators:
                   - "root"
 ```
+
 The example above will produce the following configuration files:
-#### Results: /etc/sudoers
-```
+
+#### Results: /etc/sudoers (multiple files)
+
+```ini
 # Ansible managed
 
 # Default specifications
@@ -311,8 +333,10 @@ root ALL=(ALL) ALL
 ## Include directories
 #includedir /etc/sudoers.d
 ```
+
 #### Results: /etc/sudoers.d/pingers
-```
+
+```ini
 # Ansible managed
 
 # Default override specifications
@@ -320,7 +344,8 @@ Defaults:PINGERS !requiretty
 ```
 
 #### Results: /etc/sudoers.d/root
-```
+
+```ini
 # Ansible managed
 
 # Default specifications
@@ -332,6 +357,7 @@ Defaults>root !set_logname
 ```
 
 ### Migrating a Running Sudoers Configuration to Another Host
+
 ```yaml
 ---
 - name: "Collect Existing Sudoers Facts"
@@ -358,11 +384,14 @@ Defaults>root !set_logname
       vars:
         sudoers_remove_unauthorized_included_files: True
 ```
+
 The above example provides a method of using Infrastructure-as-Code in Reverse to take a known configuration converted to structured data to drive future automation.  Alternatively to directly provisioning the collected configuration on a new host, you could push the data into a CMDB or repository for future use as a source of truth.
 
 ## License
+
 [MIT](LICENSE)
 
 ## Author Information
-[Andrew J. Huffman](https://github.com/ahuffman)  
-[Tyler Cross](https://github.com/wtcross)  
+
+[Andrew J. Huffman](https://github.com/ahuffman)
+[Tyler Cross](https://github.com/wtcross)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,8 @@ sudoers_files:
     defaults:
       - "!visiblepw"
       - "always_set_home"
-      - "match_group_by_gid"
-      - "always_query_group_plugin" # maintains sudo pre-1.8.15 group behavior
+      - "match_group_by_gid"        # NOTE: for sudo>=1.8.18
+      - "always_query_group_plugin" # NOTE: maintains sudo pre-1.8.15 group behavior
       - "env_reset"
       - secure_path:
           - "/sbin"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,8 @@ galaxy_info:
   author:
     - "Andrew J. Huffman"
     - "Tyler Cross"
+    - "Carrol Cox"
+    - "Thiago Alves"
   company: "Red Hat"
   description: "Controls the configuration of the default /etc/sudoers file and included files/directories"
   license: "MIT"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Define root group
+  vars:
+    distribution_groups:
+      MacOSX: wheel
+  set_fact:
+    sudoers_root_group: "{{ distribution_groups[ansible_distribution] | default('root') }}"
+  when: sudoers_root_group is not defined
+
 - name: "Ensure sudo is installed"
   package:
     name: "sudo"
@@ -6,6 +14,7 @@
   retries: "3"
   register: "sudo_installed"
   until: "sudo_installed is succeeded"
+  when: ansible_distribution != 'MacOSX'
   become: True
 
 - name: "Set include directories variable"
@@ -30,7 +39,7 @@
   file:
     path: "{{ item }}"
     owner: "root"
-    group: "root"
+    group: "{{ sudoers_root_group }}"
     mode: "0750"
     state: "directory"
   with_items: "{{ sudoers_include_dirs }}"
@@ -68,7 +77,7 @@
     src: "sudoers.j2"
     dest: "{{ item.path }}"
     owner: "root"
-    group: "root"
+    group: "{{ sudoers_root_group }}"
     mode: "0440"
     validate: '{{ sudoers_visudo_path }} -cf %s'
   with_items: "{{ sudoers_files }}"
@@ -82,7 +91,7 @@
     src: "sudoers.j2"
     dest: "/etc/sudoers"
     owner: "root"
-    group: "root"
+    group: "{{ sudoers_root_group }}"
     mode: "0440"
     validate: '{{ sudoers_visudo_path }} -cf %s'
   with_items: "{{ sudoers_files }}"

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% if item.defaults is defined %}
 
 # Default specifications


### PR DESCRIPTION
## Changes Description

This commit makes the "Ensure sudo is installed" to not be executed on
macOS (if you have Homebrew installed, this task fails because `brew`
cannot be executed as `root`).

It also allows the user to change the group owner used to create and
verify files. Here, if the user does not change the default value, we
check if the distribution we're running in is a MacOSX, and if it is
we use `wheel` instead of `root`.